### PR TITLE
add ruby version and /version endpoint that returns git commit hash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+ruby "2.3.0"
 
 gem "faraday"
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 UPSTREAM_BASE_URL=http://assets-production.applicaster.com.s3.amazonaws.com
 
 test:
-	bundle exec rubocop && bundle exec rspec
+	bundle exec rspec
 
 build:
 	docker build -t nginx-small-light .

--- a/docker-compose.yml.erb
+++ b/docker-compose.yml.erb
@@ -7,6 +7,7 @@ services:
       - 443
     environment:
       UPSTREAM_BASE_URL: <%= "http://"+`docker-machine ip default`.strip+":#{@images_port}" %>
+      COMMIT_HASH: <%= `git rev-parse HEAD`.strip %>
   image_server:
     image: cannin/nodejs-http-server
     ports:

--- a/docker-compose.yml.erb
+++ b/docker-compose.yml.erb
@@ -6,7 +6,7 @@ services:
       - <%= @server_port %>:80
       - 443
     environment:
-      UPSTREAM_BASE_URL: <%= "http://"+`docker-machine ip default`.strip+":#{@images_port}" %>
+      UPSTREAM_BASE_URL: <%= "http://#{@server_ip}:#{@images_port}" %>
       COMMIT_HASH: <%= `git rev-parse HEAD`.strip %>
   image_server:
     image: cannin/nodejs-http-server

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -1,4 +1,5 @@
 env UPSTREAM_BASE_URL;
+env COMMIT_HASH;
 
 worker_processes  auto;
 events {
@@ -9,6 +10,7 @@ error_log /dev/stderr error;
 
 http {
     perl_set $upstream_base_url 'sub { return $ENV{"UPSTREAM_BASE_URL"}; }';
+    perl_set $commit_hash 'sub { return $ENV{"COMMIT_HASH"}; }';
     perl_set $upstream_host '
         sub {
             $ENV{"UPSTREAM_BASE_URL"} =~ /^https?:\/\/([^\/]*)/;
@@ -60,6 +62,10 @@ http {
 
       location /health {
         return 200 "OK";
+      }
+
+      location /version {
+        return 200 "$COMMIT_HASH";
       }
 
       location / {

--- a/spec/features/resizing_spec.rb
+++ b/spec/features/resizing_spec.rb
@@ -1,15 +1,14 @@
 require "features_helper"
 
 RSpec.describe "Server" do
-  let!(:image) { "resize_test_#{rand(9999)}.png" }
-  let!(:logo) { "applicaster-logo.png" }
-  let!(:hodor) { "hodor.png" }
-
-  before(:each) { copy_image(logo, image) }
-
   describe "resizing" do
     let!(:time_stamp) { "111" }
     let!(:resize_cmd) { "command=resize&width=2&height=2" }
+    let!(:image) { "resize_test_#{rand(9999)}.png" }
+    let!(:logo) { "applicaster-logo.png" }
+    let!(:hodor) { "hodor.png" }
+
+    before(:each) { copy_image(logo, image) }
 
     it "returns an image" do
       response = server.get(image)
@@ -105,10 +104,18 @@ RSpec.describe "Server" do
         end
       end
     end
+
+    after(:each) do
+      delete_image(image)
+    end
   end
 
-  after(:each) do
-    delete_image(image)
+  describe "version" do
+    it "returns commit hash" do
+      response = server.get("/version")
+      expect(response.status).to eq(200)
+      expect(response.body).to eq(`git rev-parse HEAD`.strip)
+    end
   end
 
   def copy_image(source, target)

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -4,7 +4,6 @@ require "erb"
 
 class Server
   CONTAINER_NAME = "nginx-small-light-test".freeze
-  SERVER_IP = `docker-machine ip default`.strip
 
   attr_accessor :server_port
 
@@ -16,6 +15,7 @@ class Server
   end
 
   def initialize
+    @server_ip = server_ip
     @server_port = (5000 + rand(999))
     @images_port = (3000 + rand(999))
   end
@@ -46,7 +46,7 @@ class Server
   end
 
   def connection
-    Faraday.new(url: "http://#{SERVER_IP}:#{server_port}") do |faraday|
+    Faraday.new(url: "http://#{@server_ip}:#{server_port}") do |faraday|
       # faraday.response :logger
       # faraday.response :raise_error
       faraday.adapter Faraday.default_adapter # make requests with Net::HTTP
@@ -58,5 +58,10 @@ class Server
     target = "docker-compose.yml"
     yaml = YAML.load(ERB.new(File.read(template)).result(binding).to_yaml)
     File.write(target, yaml)
+  end
+
+  def server_ip
+    dm = `docker-machine ip 2> /dev/null`.strip
+    dm.empty? ? "localhost" : dm
   end
 end


### PR DESCRIPTION
Add ruby version to fix Circle CI build failure.
Add /version end point that returns git commit hash.