### PR TITLE
Fixed failing tests on CI 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - Gemfile
+    - vendor/bundle/**/*
 
 CollectionMethods:
   PreferredMethods:
@@ -47,3 +48,10 @@ Style/BlockDelimiters:
 
 Style/ClosingParenthesisIndentation:
   Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 100
+

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,11 @@
 machine:
   pre:
-   - sudo pip install docker==2.0.0
-   - sudo pip install docker-compose==1.7.1
-   - sudo service docker start
+    - sudo pip install docker==2.0.0
+    - sudo pip install docker-compose==1.7.1
+    - sudo service docker start
+  ruby:
+    version: 2.3.3
+
+test:
+  override:
+    - make test

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,5 @@
+machine:
+  pre:
+   - sudo pip install docker==2.0.0
+   - sudo pip install docker-compose==1.7.1
+   - sudo service docker start

--- a/docker-compose.yml.erb
+++ b/docker-compose.yml.erb
@@ -1,16 +1,14 @@
-version: '2'
-services:
-  nginx:
-    build: .
-    ports:
-      - <%= @server_port %>:80
-      - 443
-    environment:
-      UPSTREAM_BASE_URL: <%= "http://"+`docker-machine ip default`.strip+":#{@images_port}" %>
-  image_server:
-    image: cannin/nodejs-http-server
-    ports:
-      - <%= @images_port %>:8080
-    volumes:
-      - ./spec/fixtures:/home
-    command: http-server -od --cors /home
+nginx:
+  build: .
+  ports:
+    - <%= @server_port %>:80
+    - 443
+  environment:
+    UPSTREAM_BASE_URL: <%= "http://#{@server_ip}:#{@images_port}" %>
+image_server:
+  image: cannin/nodejs-http-server
+  ports:
+    - <%= @images_port %>:8080
+  volumes:
+    - ./spec/fixtures:/home
+  command: http-server -od --cors /home

--- a/docker-compose.yml.erb
+++ b/docker-compose.yml.erb
@@ -12,3 +12,4 @@ image_server:
   volumes:
     - ./spec/fixtures:/home
   command: http-server -od --cors /home
+


### PR DESCRIPTION
@vinagrito 
This PR solves the issue with our local tests passing (using docker-machine) but failing on circleci (which uses a linux box and has no docker-machine)
The solution required:

- Adding logic to get docker ip when docker-machine is not available
- Adding a `circle.yml` file that
  - Installs newer versions of `docker` and `docker-compose`
  - Starts the docker service
- Downgrade `docker-compose.yml` to `v1`. CI is currently incapable of dealing with `v2`.